### PR TITLE
Rename SubscriptionId variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TF_VAR_location=eastus
 TF_VAR_prefix=pktmtbrc
-AZURE_SUBSCRIPTION_ID=<subscription_id>
+TF_VAR_subscription_id=<subscription_id>
 
 # Auto-generated values will go under this section.
 # Please also copy this to you .env file.


### PR DESCRIPTION
The SubscriptionId that is initially setup should be using TF_VAR_subscription_id so that Terraform can read it.