### PR TITLE
Remove the server from the openapi spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ extract-prod: ## 📤 Export the development API Management instance to a temp l
 		&& export AZURE_RESOURCE_GROUP_NAME=${PROD_RESOURCE_GROUP_NAME} \
 		&& extractor
 
-publish-dev: artifacts-dev ## 📤 Publish to the development API Management instance
+publish-dev: artifacts ## 📤 Publish to the development API Management instance
 	@echo -e "\e[34m$@\e[0m" || true
 	@export API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH=apim_artifacts \
 		&& export API_MANAGEMENT_SERVICE_NAME=${DEV_APIM_NAME} \
@@ -46,7 +46,7 @@ publish-dev: artifacts-dev ## 📤 Publish to the development API Management ins
 		&& export CONFIGURATION_YAML_PATH="./apim_artifacts/configuration.dev.yaml" \
 		&& publisher
 
-# publish-prod: artifacts-prod ## 📤 Publish to the production API Management instance
+# publish-prod: artifacts ## 📤 Publish to the production API Management instance
 # 	@echo -e "\e[34m$@\e[0m" || true
 # 	@export API_MANAGEMENT_SERVICE_OUTPUT_FOLDER_PATH=apim_artifacts \
 # 		&& export API_MANAGEMENT_SERVICE_NAME=${PROD_APIM_NAME} \
@@ -54,12 +54,6 @@ publish-dev: artifacts-dev ## 📤 Publish to the development API Management ins
 # 		&& export CONFIGURATION_YAML_PATH="./apim_artifacts/configuration.prod.yaml" \
 # 		&& publisher
 
-artifacts-dev: ## ⚙️ Create APIM Artifacts based on environment variables
+artifacts: ## ⚙️ Create APIM Artifacts based on environment variables
 	@echo -e "\e[34m$@\e[0m" || true
-	@export API_MANAGEMENT_SERVICE_NAME=${DEV_APIM_NAME} \
-		&& ./scripts/create_apimartifacts.sh
-
-artifacts-prod: ## ⚙️ Create APIM Artifacts based on environment variables
-	@echo -e "\e[34m$@\e[0m" || true
-	@export API_MANAGEMENT_SERVICE_NAME=${PROD_APIM_NAME} \
-		&& ./scripts/create_apimartifacts.sh
+	@./scripts/create_apimartifacts.sh

--- a/apim_templates/apis/swagger-petstore-v2/specification.yaml
+++ b/apim_templates/apis/swagger-petstore-v2/specification.yaml
@@ -9,9 +9,6 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: '2.0'
-servers:
-  - url: http://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
-  - url: https://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
 paths:
   '/pet/{petId}/uploadImage':
     post:

--- a/apim_templates/apis/swagger-petstore-v3/specification.yaml
+++ b/apim_templates/apis/swagger-petstore-v3/specification.yaml
@@ -9,9 +9,6 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: '3.0'
-servers:
-  - url: http://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
-  - url: https://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
 paths:
   '/pet/{petId}/uploadImage':
     post:

--- a/apim_templates/apis/swagger-petstore/specification.yaml
+++ b/apim_templates/apis/swagger-petstore/specification.yaml
@@ -9,9 +9,6 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: '1.0'
-servers:
-  - url: http://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
-  - url: https://${API_MANAGEMENT_SERVICE_NAME}.azure-api.net
 paths:
   '/pet/{petId}/uploadImage':
     post:


### PR DESCRIPTION
The specification.yaml do not require the server uri defined in them. When published to an APIM, it defaults to / as documented here: - https://swagger.io/docs/specification/api-host-and-base-path/

Fixes #56