### PR TITLE
Apiops dev container feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,25 +14,9 @@
 		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {
 			"version": "latest"
 		},
-		"ghcr.io/azure/azure-dev/azd:0": {
-			"version": "stable"
-		},
-		// "ghcr.io/devcontainers-contrib/features/gh-release:1": {
-		// 	"repo": "Azure/apiops",
-		// 	"version": "v4.8.0",
-		// 	"binaryNames": "extractor",
-		// 	"assetRegex": "^(extractor.linux-x64.exe)"
-		// },
-		"ghcr.io/devcontainers-contrib/features/gh-release:1": {
-			"repo": "Azure/apiops",
-			"version": "v4.8.0",
-			"binaryNames": "publisher",
-			"assetRegex": "^(publisher.linux-x64.exe)"
+		"ghcr.io/devcontainers-contrib/features/azure-apiops:latest": {
 		}
 	},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
There is now a devcontainer feature called `azure-apiops` which will install the publisher and extractor into your devcontainer.

Documentation page is https://github.com/devcontainers-contrib/features/tree/main/src/azure-apiops